### PR TITLE
GLUC-014-006: Reset Weekly Meal Planner Every Sunday

### DIFF
--- a/src/application/GlucoseGenie/GlucoseGenie/Settings/View/WeeklyMealPlanView.swift
+++ b/src/application/GlucoseGenie/GlucoseGenie/Settings/View/WeeklyMealPlanView.swift
@@ -163,6 +163,9 @@ struct WeeklyMealPlanView: View {
                 }
             }
         }
+        .onAppear{
+            store.resetIfNewWeek()
+        }
     }
 }
 

--- a/src/application/GlucoseGenie/GlucoseGenie/Utils/RecipeStore.swift
+++ b/src/application/GlucoseGenie/GlucoseGenie/Utils/RecipeStore.swift
@@ -35,6 +35,7 @@ final class RecipeStore: ObservableObject {
 
   private let savedKey = "saved_recipes"
   private let planKey  = "weekly_plan"
+  private let lastResetDate = "last_reset_date"
 
   init() { load() }
 
@@ -61,6 +62,25 @@ final class RecipeStore: ObservableObject {
   func clearPlan() {
     plan.removeAll()
     save()
+  }
+    
+  func resetIfNewWeek() {
+    let calendar = Calendar.current
+    let today = Date()
+
+    // Start of the current week (Sunday)
+    let startOfThisWeek = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today))!
+
+    if let lastResetData = UserDefaults.standard.object(forKey: lastResetDate) as? Date {
+        // Clear plan if new week
+        if !calendar.isDate(lastResetData, equalTo: today, toGranularity: .weekOfYear) {
+            clearPlan()
+            UserDefaults.standard.set(startOfThisWeek, forKey: lastResetDate)
+        }
+    } else {
+        // First time setup; store current Sunday
+        UserDefaults.standard.set(startOfThisWeek, forKey: lastResetDate)
+    }
   }
 
   private func load() {


### PR DESCRIPTION
The weekly meal planner should now be cleared whenever a new week starts i.e. every Sunday.
I tested this by changing my MacBook's date which in turn changes the date in the iPhone simulator. I closed and opened the calendar app to check if the date had changed, then I re-opened GlucoseGenie. I never opened the app to the weekly meal planner page directly; I always went back to the main menu before changing the date and re-opening the app.

The planner should only reset if a new Sunday has occurred.
If a user opens the meal planner multiple times on a Sunday, the plan should only be reset the initial time.

Ideally, I believe this behavior should be a toggle setting, but XCode was fighting me when I tried to modify the Settings View. If we do not make this a setting we should explain this feature in the User Manual.